### PR TITLE
Add "requireSpacesInsideParentheses" rule to the JSCS config.

### DIFF
--- a/dev/tasks/jscs-config.json
+++ b/dev/tasks/jscs-config.json
@@ -22,6 +22,7 @@
 	"requireBlocksOnNewline": true,
 	"requireSpacesInsideObjectBrackets": "all",
 	"requireSpacesInsideArrayBrackets": "all",
+	"requireSpacesInsideParentheses": "all",
 	"disallowSpaceAfterObjectKeys": true,
 	"requireCommaBeforeLineBreak": true,
 	"requireOperatorBeforeLineBreak": [


### PR DESCRIPTION
This comment:
https://github.com/cksource/ckeditor-plugin-a11ychecker/pull/209#discussion_r66076662
made me realize, that currently there's no rule enforcing the desired code style in this case, so here it is.