### PR TITLE
Add close event as possible alternative to handling closing in the Viewer.

### DIFF
--- a/ui/Viewer.js
+++ b/ui/Viewer.js
@@ -82,24 +82,26 @@ define( [
 			that.editor.focusManager.remove( elem );
 		};
 
+		var hide = CKEDITOR.tools.bind( function( evt ) {
+			this.fire( 'close' );
+
+			if ( evt && evt.data ) {
+				evt.data.preventDefault();
+			}
+		}, this );
+
 		// Hide the panel once the closing X is clicked.
 		this.panel.addShowListener( function() {
-			return this.parts.close.on( 'click', function( evt ) {
-				this.blur();
-				this.hide();
-				evt.data.preventDefault();
-			}, this );
+			return this.parts.close.on( 'click', hide );
 		} );
 
 		this.panel.addShowListener( function() {
-			return this.parts.panel.on( 'keydown', function( evt ) {
+			return this.parts.close.on( 'keydown', function( evt ) {
 				var keystroke = evt.data.getKeystroke();
 
-				// Hide the panel on ESC key press.
-				if ( keystroke == 27 ) {
-					this.blur();
-					this.hide();
-					evt.data.preventDefault();
+				// Hide the panel on space or ESC key press in close button.
+				if ( keystroke == 32 || keystroke == 27 ) {
+					hide.call( null, evt );
 				}
 			}, this );
 		} );
@@ -362,6 +364,13 @@ define( [
 		}
 	};
 
+	/**
+	 * Fires when there's a request to close the viever originating from any of the UI elements.
+	 *
+	 * @event close
+	 */
+
+	CKEDITOR.event.implementOn( Viewer.prototype );
 
 	return Viewer;
 } );

--- a/ui/ViewerController.js
+++ b/ui/ViewerController.js
@@ -56,10 +56,11 @@ define( [ 'ui/Viewer' ], function( Viewer ) {
 			this.update( a11ychecker.issues.getFocused() );
 		}, this );
 
+
 		// When balloon is closed, a11ychecker should be forced to close with it.
 		// We can't listen to balloon hide event, because it's raised when the dialog
 		// is closed during issue switch.
-		viewer.panel.parts.close.on( 'click', function( evt ) {
+		viewer.on( 'close', function() {
 			this.a11ychecker.close();
 		}, this );
 


### PR DESCRIPTION
This PR is related to this:
https://github.com/cksource/ckeditor-plugin-a11ychecker/issues/200#issuecomment-226125446
comment and should fix the problem in #200 without breaking encapsulation.

The idea is for the `Viewer` to implement the `CKEDITOR.event` interface and emit a close whenever the user wishes to close AC. The `ViewerController` can listen on that event and act accordingly.