### PR TITLE
Update benderjs-amd version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {},
   "devDependencies": {
     "amdclean": "~2.2.4",
-    "benderjs-amd": "^0.2.3",
+    "benderjs-amd": "^0.2.4",
     "chai": "^1.9.1",
     "colors": "~1.0.3",
     "grunt": "~0.4.5",


### PR DESCRIPTION
In order to fix #212 we need to update benderjs-amd version. We've already made all necessary changes in upstream project and published all the npm packages.