### PR TITLE
T/204 provide custom Quail path.

### DIFF
--- a/quailInclude.js
+++ b/quailInclude.js
@@ -31,7 +31,7 @@ require( [ 'EngineQuailConfig' ], function( _EngineQuailConfig ) {
 	EngineQuailConfig = _EngineQuailConfig;
 } );
 
-(function() {
+( function() {
 	if ( !$ || !$.fn ) {
 		throw new Error( 'Missing jQuery. Accessibility Checker\'s default engine, Quail.js requires jQuery ' +
 			'to work correctly.' );
@@ -39,14 +39,27 @@ require( [ 'EngineQuailConfig' ], function( _EngineQuailConfig ) {
 
 	// We'll load custom Quail only if it's not already registered.
 	if ( $.fn.quail ) {
+		includeEngineQuailAndContinue();
 		return;
 	}
-/*@include libs/quail/quail.jquery.min.js */
-}());
 
-Quail = $.fn.quail;
+	var quailPath = 'plugins/a11ychecker/libs/quail/quail.jquery.min.js' || CKEDITOR.config.a11ychecker_quailPath;
 
-/*@include ../../EngineQuail.js */
+	CKEDITOR.scriptLoader.load( [ quailPath ], function( completed ) {
+		if ( completed ) {
+			includeEngineQuailAndContinue();
 
-callback( EngineQuail );
+		} else {
+			throw new Error( 'Could not load Quail' );
+		}
+	} );
+
+	function includeEngineQuailAndContinue() {
+		Quail = $.fn.quail;
+
+		/*@include ../../EngineQuail.js */
+
+		callback( EngineQuail );
+	}
+}() );
 /* jshint ignore:end */

--- a/quailInclude.js
+++ b/quailInclude.js
@@ -17,49 +17,64 @@
  * actually load it async at runtime, it would keep the file smaller).
  */
 
-var acNamespace = CKEDITOR.plugins.a11ychecker,
-	Engine = acNamespace.Engine,
-	IssueList = acNamespace.IssueList,
-	Issue = acNamespace.Issue,
-	IssueDetails = acNamespace.IssueDetails,
-	Quail,
-	EngineQuailConfig,
-	$ = window.jQuery || window.$;
+/* @exclude */
+define( [
+	'window',
+	'callback',
+	'EngineQuail'
+], function( window, callback, EngineQuail ) {
+/* @endexclude */
+	function quailInclude() {
+		var acNamespace = CKEDITOR.plugins.a11ychecker,
+			Engine = acNamespace.Engine,
+			IssueList = acNamespace.IssueList,
+			Issue = acNamespace.Issue,
+			IssueDetails = acNamespace.IssueDetails,
+			Quail,
+			EngineQuailConfig,
+			$ = window.jQuery || window.$;
 
-// EngineQuailConfig class can still be loaded with RequireJS as it does not have any deps.
-require( [ 'EngineQuailConfig' ], function( _EngineQuailConfig ) {
-	EngineQuailConfig = _EngineQuailConfig;
-} );
+		// EngineQuailConfig class can still be loaded with RequireJS as it does not have any deps.
+		require( [ 'EngineQuailConfig' ], function( _EngineQuailConfig ) {
+			EngineQuailConfig = _EngineQuailConfig;
+		} );
 
-( function() {
-	if ( !$ || !$.fn ) {
-		throw new Error( 'Missing jQuery. Accessibility Checker\'s default engine, Quail.js requires jQuery ' +
-			'to work correctly.' );
-	}
 
-	// We'll load custom Quail only if it's not already registered.
-	if ( $.fn.quail ) {
-		includeEngineQuailAndContinue();
-		return;
-	}
-
-	var quailPath = 'plugins/a11ychecker/libs/quail/quail.jquery.min.js' || CKEDITOR.config.a11ychecker_quailPath;
-
-	CKEDITOR.scriptLoader.load( [ quailPath ], function( completed ) {
-		if ( completed ) {
-			includeEngineQuailAndContinue();
-
-		} else {
-			throw new Error( 'Could not load Quail' );
+		if ( !$ || !$.fn ) {
+			throw new Error( 'Missing jQuery. Accessibility Checker\'s default engine, Quail.js requires jQuery ' +
+				'to work correctly.' );
 		}
-	} );
 
-	function includeEngineQuailAndContinue() {
-		Quail = $.fn.quail;
+		// We'll load custom Quail only if it's not already registered.
+		if ( $.fn.quail ) {
+			includeEngineQuailAndContinue();
+			return;
+		}
 
-		/*@include ../../EngineQuail.js */
+		var quailPath = 'plugins/a11ychecker/libs/quail/quail.jquery.min.js' || CKEDITOR.config.a11ychecker_quailPath;
 
-		callback( EngineQuail );
+		CKEDITOR.scriptLoader.load( [ quailPath ], function( completed ) {
+
+			if ( completed.length ) {
+				includeEngineQuailAndContinue();
+			} else {
+				throw new Error( 'Could not load Quail' );
+			}
+		} );
+
+		function includeEngineQuailAndContinue() {
+			Quail = $.fn.quail;
+
+			/*@include ../../EngineQuail.js */
+
+			callback( EngineQuail );
+		}
 	}
-}() );
+
+	quailInclude();
+/* @exclude */
+	return quailInclude;
+} );
+/* @endexclude */
+
 /* jshint ignore:end */

--- a/tests/quailinclude.js
+++ b/tests/quailinclude.js
@@ -1,0 +1,55 @@
+( function() {
+	'use strict';
+
+	CKEDITOR.plugins.a11ychecker = {
+		Engine: {}
+	};
+
+	define( 'window', [], function() {
+		return {
+			jQuery: {
+				fn: {}
+			}
+		};
+	} );
+
+	define( 'EngineQuail', [], function() {} );
+
+	define( 'callback', [], function() {
+		return function() {};
+	} );
+
+	function mockLoad( success, onEnd ) {
+		CKEDITOR.scriptLoader.load = function( path, callback ) {
+			try {
+				callback( success ? [ path ] : [] );
+			} catch ( e ) {
+				onEnd( e );
+				return;
+			}
+			onEnd( null );
+		};
+	}
+
+	mockLoad( true, function() {} );
+
+	bender.require( [ 'quailInclude' ], function( quailInclude ) {
+		bender.test( {
+			'test wrong Quail path throws exception': function() {
+				mockLoad( false, function( error ) {
+					assert.isObject( error );
+					assert.areEqual( 'Could not load Quail', error.message );
+				} );
+
+				quailInclude();
+			},
+			'test correct Quail path does not throw exception': function() {
+				mockLoad( true, function( error ) {
+					assert.isNull( error );
+				} );
+
+				quailInclude();
+			}
+		} );
+	} );
+} )();

--- a/tests/quailinclude.js
+++ b/tests/quailinclude.js
@@ -1,3 +1,5 @@
+/* bender-tags: unit,1.0.1,204 */
+
 ( function() {
 	'use strict';
 


### PR DESCRIPTION
Fixes #204.

Making a manual test here was not much of an option since normally `quailInclude.js` is present only in the built version.

With some modifications though it was possible to create a unit test which checks whether an error is thrown in case the loading fails.