### PR TITLE
Introduced process event in the Engine type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Copyright (c) 2014-2018, CKSource - Frederico Knabben. All rights reserved.
 ## Version 1.1.1
 
 * [#233](https://github.com/cksource/ckeditor-plugin-a11ychecker/issues/233): Fixed: Balloon classes are localized, causing issues of a different testability look the same.
+* [#247](https://github.com/cksource/ckeditor-plugin-a11ychecker/issues/247): Introduced `process` event in the `Engine` type, allowing for adding custom issue types.
 
 ## Version 1.1.0
 

--- a/Engine.js
+++ b/Engine.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or http://ckeditor.com/license
  */
 
-define( function() {
+define( [ 'IssueList' ], function( IssueList ) {
 	'use strict';
 
 	/**
@@ -16,6 +16,7 @@ define( function() {
 	 * methods, if the default behavior is not suitable.
 	 *
 	 * @since 4.6.0
+	 * @mixins CKEDITOR.event
 	 * @class CKEDITOR.plugins.a11ychecker.Engine
 	 * @constructor
 	 */
@@ -44,6 +45,8 @@ define( function() {
 		config: {}
 	};
 
+	CKEDITOR.event.implementOn( Engine.prototype );
+
 	Engine.prototype.constructor = Engine;
 
 	/**
@@ -60,8 +63,24 @@ define( function() {
 	 * @param {CKEDITOR.plugins.a11ychecker.Controller} a11ychecker
 	 * @param {CKEDITOR.dom.element} contentElement DOM object of container which contents will be checked.
 	 * @param {Function} callback
+	 * @returns {Boolean} `false` if the processing has been canceled, `true` otherwise.
 	 */
 	Engine.prototype.process = function( a11ychecker, contentElement, callback ) {
+		var issues = new IssueList();
+
+		if ( this.fire( 'process', { issues: issues } ) === false ) {
+			return false;
+		}
+
+		if ( callback ) {
+			if ( this.fire( 'processed', { issues: issues } ) === false ) {
+				return false;
+			}
+
+			callback( issues );
+		}
+
+		return true;
 	};
 
 	/**

--- a/Engine.js
+++ b/Engine.js
@@ -221,6 +221,7 @@ define( [ 'IssueList' ], function( IssueList ) {
 	 *
 	 * Note that this even happens before issue engine is engaged.
 	 *
+	 * @since 1.1.1
 	 * @event process
 	 * @member CKEDITOR.plugins.a11ychecker.Engine
 	 * @param {Object} data

--- a/Engine.js
+++ b/Engine.js
@@ -68,12 +68,15 @@ define( [ 'IssueList' ], function( IssueList ) {
 	Engine.prototype.process = function( a11ychecker, contentElement, callback ) {
 		var issues = new IssueList();
 
-		if ( this.fire( 'process', { issues: issues } ) === false ) {
+		if ( this.fire( 'process', {
+			issues: issues,
+			contentElement: contentElement
+		} ) === false ) {
 			return false;
 		}
 
 		if ( callback ) {
-			if ( this.fire( 'processed', { issues: issues } ) === false ) {
+			if ( this.fire( 'processed', { issues: issues, contentElement: contentElement } ) === false ) {
 				return false;
 			}
 
@@ -214,6 +217,20 @@ define( [ 'IssueList' ], function( IssueList ) {
 	 * @type {Function/null}
 	 */
 	Engine.prototype._filterIssue = null;
+
+	/**
+	 * Event fired when the engine is about to start processing the rules.
+	 *
+	 * It can be cancelled meaning that no further processing will be performed.
+	 *
+	 * Note that this even happens before issue engine is engaged.
+	 *
+	 * @event process
+	 * @member CKEDITOR.plugins.a11ychecker.Engine
+	 * @param {Object} data
+	 * @param {CKEDITOR.plugins.a11ychecker.IssueList} data.issues List of issues to be returned.
+	 * @param {CKEDITOR.dom.element} data.contentElement See `contentElement` parameter in the {@link #process process method}.
+	 */
 
 	return Engine;
 } );

--- a/Engine.js
+++ b/Engine.js
@@ -76,10 +76,6 @@ define( [ 'IssueList' ], function( IssueList ) {
 		}
 
 		if ( callback ) {
-			if ( this.fire( 'processed', { issues: issues, contentElement: contentElement } ) === false ) {
-				return false;
-			}
-
 			callback( issues );
 		}
 

--- a/EngineQuail.js
+++ b/EngineQuail.js
@@ -106,7 +106,7 @@ define( [
 				// Method to be executed after Quail checking is complete.
 				// It will extract the issues.
 				testCollectionComplete: function( evtName, collection ) {
-					var issueList = that.getIssuesFromCollection( collection, a11ychecker.editor );
+					var issueList = that.getIssuesFromCollection( collection, a11ychecker.editor, issues );
 
 					that.filterIssues( issueList, contentElement );
 
@@ -135,8 +135,8 @@ define( [
 	 * @param {CKEDITOR.editor} editor
 	 * @returns {CKEDITOR.a11ychecker.plugins.IssuesList}
 	 */
-	EngineQuail.prototype.getIssuesFromCollection = function( collection, editor ) {
-		var ret = new IssueList(),
+	EngineQuail.prototype.getIssuesFromCollection = function( collection, editor, issues ) {
+		var ret = issues || new IssueList(),
 			that = this;
 
 		collection.each( function( index, test ) {

--- a/EngineQuail.js
+++ b/EngineQuail.js
@@ -92,15 +92,17 @@ define( [
 		var $ = window.jQuery,
 			// Quail config, we'll have to override few options here.
 			config = a11ychecker.editor.config.a11ychecker_quailParams || {},
-			that = this,
+			that = this;
+
+		return Engine.prototype.process.call( this, a11ychecker, contentElement, function( issues ) {
 			// Options to be overridden in config, as they are essential for us.
-			quailConfigOverride = {
+			var quailConfigOverride = {
 				/**
 				 * @todo: Not sure if reset param is still needed in 2.2.8+ version.
 				 */
 				// Causes total.results to be new in each call.
 				reset: true,
-				guideline: this.config.guideline,
+				guideline: that.config.guideline,
 				// Method to be executed after Quail checking is complete.
 				// It will extract the issues.
 				testCollectionComplete: function( evtName, collection ) {
@@ -114,14 +116,15 @@ define( [
 				}
 			};
 
-		CKEDITOR.tools.extend( config, quailConfigOverride, true );
+			CKEDITOR.tools.extend( config, quailConfigOverride, true );
 
-		if ( !config.jsonPath ) {
-			config.jsonPath = this.jsonPath;
-		}
+			if ( !config.jsonPath ) {
+				config.jsonPath = that.jsonPath;
+			}
 
-		// Execute Quail checking.
-		$( contentElement.$ ).quail( config );
+			// Execute Quail checking.
+			$( contentElement.$ ).quail( config );
+		} );
 	};
 
 	/**

--- a/tests/Engine.js
+++ b/tests/Engine.js
@@ -168,12 +168,10 @@
 				var engine = new Engine(),
 					callback = sinon.spy(),
 					processListener = sinon.spy(),
-					processedListener = sinon.spy(),
 					fakeContentElement = CKEDITOR.document.createElement( 'div' ),
 					ret;
 
 				engine.on( 'process', processListener );
-				engine.on( 'processed', processedListener );
 
 				ret = engine.process( null, fakeContentElement, callback );
 
@@ -186,9 +184,6 @@
 					eventDataPropertyMatcher( 'contentElement', CKEDITOR.dom.element ) );
 				sinon.assert.calledOn( processListener, engine );
 
-				assert.areSame( 1, processedListener.callCount, 'Processed event count' );
-				sinon.assert.calledWithExactly( processedListener, eventDataPropertyMatcher( 'issues', IssueList ) );
-
 				assert.isTrue( ret, 'Return value' );
 
 				function eventDataPropertyMatcher( propertyName, expectedType ) {
@@ -199,27 +194,9 @@
 			'test Engine process event can be canceled': function() {
 				var engine = new Engine(),
 					callback = sinon.spy(),
-					processedListener = sinon.spy(),
 					ret;
 
 				engine.on( 'process', function( evt ) {
-					evt.cancel();
-				} );
-				engine.on( 'processed', processedListener );
-
-				ret = engine.process( null, null, callback );
-
-				assert.areSame( 0, processedListener.callCount, 'Processed event count' );
-				assert.areSame( 0, callback.callCount, 'Callback call count' );
-				assert.isFalse( ret, 'Return value' );
-			},
-
-			'test Engine processed event can be canceled': function() {
-				var engine = new Engine(),
-					callback = sinon.spy(),
-					ret;
-
-				engine.on( 'processed', function( evt ) {
 					evt.cancel();
 				} );
 

--- a/tests/Engine.js
+++ b/tests/Engine.js
@@ -9,7 +9,7 @@
 	/*jshint -W020 */
 	'use strict';
 
-	bender.require( [ 'Engine', 'mocking' ], function( Engine, mocking ) {
+	bender.require( [ 'Engine', 'IssueList', 'mocking' ], function( Engine, IssueList, mocking ) {
 
 		bender.test( {
 			'test Engine.getFixType': function() {
@@ -162,6 +162,67 @@
 				assert.areSame( 1, engine._filterIssue.callCount, 'Engine._filterIssue call count' );
 				assert.areSame( sketchpad, engine._filterIssue.args[ 0 ][ 1 ],
 					'Sketchpad is given as a second param' );
+			},
+
+			'test Engine.process': function() {
+				var engine = new Engine(),
+					callback = sinon.spy(),
+					processListener = sinon.spy(),
+					processedListener = sinon.spy(),
+					ret;
+
+				engine.on( 'process', processListener );
+				engine.on( 'processed', processedListener );
+
+				ret = engine.process( null, null, callback );
+
+				assert.areSame( 1, callback.callCount, 'Callback calls' );
+				sinon.assert.calledWithExactly( callback, sinon.match.instanceOf( IssueList ) );
+
+				assert.areSame( 1, processListener.callCount, 'Process event count' );
+				sinon.assert.calledWithExactly( processListener, eventDataPropertyMatcher( 'issues', IssueList ) );
+
+				assert.areSame( 1, processedListener.callCount, 'Processed event count' );
+				sinon.assert.calledWithExactly( processedListener, eventDataPropertyMatcher( 'issues', IssueList ) );
+
+				assert.isTrue( ret, 'Return value' );
+
+				function eventDataPropertyMatcher( propertyName, expectedType ) {
+					return sinon.match.has( 'data', sinon.match.has( propertyName, sinon.match.instanceOf( expectedType ) ) );
+				}
+			},
+
+			'test Engine process event can be canceled': function() {
+				var engine = new Engine(),
+					callback = sinon.spy(),
+					processedListener = sinon.spy(),
+					ret;
+
+				engine.on( 'process', function( evt ) {
+					evt.cancel();
+				} );
+				engine.on( 'processed', processedListener );
+
+				ret = engine.process( null, null, callback );
+
+				assert.areSame( 0, processedListener.callCount, 'Processed event count' );
+				assert.areSame( 0, callback.callCount, 'Callback call count' );
+				assert.isFalse( ret, 'Return value' );
+			},
+
+			'test Engine processed event can be canceled': function() {
+				var engine = new Engine(),
+					callback = sinon.spy(),
+					ret;
+
+				engine.on( 'processed', function( evt ) {
+					evt.cancel();
+				} );
+
+				ret = engine.process( null, null, callback );
+
+				assert.areSame( 0, callback.callCount, 'Callback call count' );
+				assert.isFalse( ret, 'Return value' );
 			},
 
 			'test Engine.filterIssues no filter': function() {

--- a/tests/Engine.js
+++ b/tests/Engine.js
@@ -169,18 +169,22 @@
 					callback = sinon.spy(),
 					processListener = sinon.spy(),
 					processedListener = sinon.spy(),
+					fakeContentElement = CKEDITOR.document.createElement( 'div' ),
 					ret;
 
 				engine.on( 'process', processListener );
 				engine.on( 'processed', processedListener );
 
-				ret = engine.process( null, null, callback );
+				ret = engine.process( null, fakeContentElement, callback );
 
 				assert.areSame( 1, callback.callCount, 'Callback calls' );
 				sinon.assert.calledWithExactly( callback, sinon.match.instanceOf( IssueList ) );
 
 				assert.areSame( 1, processListener.callCount, 'Process event count' );
 				sinon.assert.calledWithExactly( processListener, eventDataPropertyMatcher( 'issues', IssueList ) );
+				sinon.assert.calledWithExactly( processListener,
+					eventDataPropertyMatcher( 'contentElement', CKEDITOR.dom.element ) );
+				sinon.assert.calledOn( processListener, engine );
 
 				assert.areSame( 1, processedListener.callCount, 'Processed event count' );
 				sinon.assert.calledWithExactly( processedListener, eventDataPropertyMatcher( 'issues', IssueList ) );

--- a/tests/EngineQuail.js
+++ b/tests/EngineQuail.js
@@ -282,7 +282,8 @@
 					engineMock = {
 						config: {
 							guideline: [ 'foo', 'bar' ]
-						}
+						},
+						fire: sinon.spy()
 					},
 					// Lets replace jQuery for a mock which will return an imitation of quail function.
 					// This function will assert parameters given to the Quail.

--- a/tests/manual/processevent.html
+++ b/tests/manual/processevent.html
@@ -1,0 +1,66 @@
+<style>
+	/* Style the body this way due to a known issue with Balloon Panel in Bender */
+	body {
+		margin-left: 0px;
+		padding-left: 320px;
+	}
+</style>
+
+<h2>Classic editor</h2>
+
+<textarea id="editor1" cols="10" rows="10">
+	&lt;p&gt;This &lt;strong&gt;is&lt;/strong&gt; a &lt;strong&gt;sample&lt;/strong&gt; &lt;em&gt;text&lt;/em&gt;.&lt;/p&gt;
+</textarea>
+
+<h2>Inline editor</h2>
+
+<div contenteditable="true" id="editor2">
+	<p>This <strong>is</strong> a <strong>sample</strong> <em>text</em>.</p>
+</div>
+
+<script>
+	var commonConfig = {
+		height: 150,
+		on: {
+			instanceReady: function() {
+				var editor = this,
+					a11ychecker = editor._.a11ychecker;
+
+				// Depending on whether it's a dev version or not AC might not yet be available.
+				if ( a11ychecker.exec ) {
+					testCode( editor )
+				} else {
+					a11ychecker.once( 'loaded', function() {
+						testCode( editor );
+					} );
+				}
+
+				function testCode( editor ) {
+					var a11ychecker = editor._.a11ychecker;
+
+					a11ychecker.engine.on( 'process', function( evt ) {
+						var Issue = CKEDITOR.plugins.a11ychecker.Issue,
+							strongs = evt.data.contentElement.find( 'strong' ),
+							issues = evt.data.issues;
+
+						a11ychecker.engine.issueDetails.avoidStrongs = {
+							title: 'Avoid strongs',
+							descr: 'Our users do not like <strong>strongs</strong>, use <em>emphasize</em> instead 😉'
+						}
+
+						CKEDITOR.tools.array.forEach( strongs.toArray(), function( strong ) {
+							issues.addItem( new Issue( {
+								originalElement: strong,
+								testability: Issue.testability.ERROR,
+								id: 'avoidStrongs'
+							}, a11ychecker.engine ) );
+						} );
+					} );
+				};
+			}
+		}
+	}
+
+	CKEDITOR.replace( 'editor1', commonConfig );
+	CKEDITOR.inline( 'editor2', commonConfig );
+</script>

--- a/tests/manual/processevent.html
+++ b/tests/manual/processevent.html
@@ -32,33 +32,39 @@
 				var editor = this,
 					a11ychecker = editor._.a11ychecker;
 
-				// Depending on whether it's a dev version or not AC might not yet be available.
+				// Depending on whether it's a dev version or not AC might not yet be available (#246).
 				if ( a11ychecker.exec ) {
-					testCode( editor )
+					a11yCheckerReady( editor )
 				} else {
 					a11ychecker.once( 'loaded', function() {
-						testCode( editor );
+						a11yCheckerReady( editor );
 					} );
 				}
 
-				function testCode( editor ) {
+				// This function simply registers meta data of our custom Issues.
+				function registerCustomIssueTypes( a11ychecker ) {
+					a11ychecker.engine.issueDetails.preferHttpsLinks = {
+						title: 'Prefer HTTPS links',
+						descr: 'It\'s year ' + ( new Date() ).getFullYear() + ' already - our website uses HTTPS. ' +
+							'You should use safe protocol whenever possible.'
+					};
+
+					a11ychecker.engine.issueDetails.avoidStrongs = {
+						title: 'Avoid strongs',
+						descr: 'Our users do not like <strong>strongs</strong>, use <em>emphasize</em> instead 😉'
+					};
+				}
+
+				function a11yCheckerReady( editor ) {
 					var a11ychecker = editor._.a11ychecker;
 
+					registerCustomIssueTypes( a11ychecker );
+
 					a11ychecker.engine.on( 'process', function( evt ) {
+						// This is where the actual checking occurs, and this is where you want to report custom issues.
 						var Issue = CKEDITOR.plugins.a11ychecker.Issue,
 							contentElement = evt.data.contentElement,
 							issues = evt.data.issues;
-
-						a11ychecker.engine.issueDetails.preferHttpsLinks = {
-							title: 'Prefer HTTPS links',
-							descr: 'It\'s year ' + ( new Date() ).getFullYear() + ' already - our website uses HTTPS. ' +
-								'You should use safe protocol whenever possible.'
-						};
-
-						a11ychecker.engine.issueDetails.avoidStrongs = {
-							title: 'Avoid strongs',
-							descr: 'Our users do not like <strong>strongs</strong>, use <em>emphasize</em> instead 😉'
-						};
 
 						CKEDITOR.tools.array.forEach( contentElement.find( 'a[href^="http://ckeditor.com"]' ).toArray(), function( link ) {
 							issues.addItem( new Issue( {

--- a/tests/manual/processevent.html
+++ b/tests/manual/processevent.html
@@ -9,12 +9,18 @@
 <h2>Classic editor</h2>
 
 <textarea id="editor1" cols="10" rows="10">
+	&lt;p&gt;This is a &lt;a href=&quot;http://ckeditor.com&quot;&gt;http link&lt;/a&gt; that should be changed to a &lt;a href=&quot;https://ckeditor.com&quot;&gt;https link like this.&lt;/a&gt;&lt;/p&gt;
 	&lt;p&gt;This &lt;strong&gt;is&lt;/strong&gt; a &lt;strong&gt;sample&lt;/strong&gt; &lt;em&gt;text&lt;/em&gt;.&lt;/p&gt;
 </textarea>
 
 <h2>Inline editor</h2>
 
 <div contenteditable="true" id="editor2">
+	<p>
+		This is a
+		<a href="http://ckeditor.com">http link</a> that should be changed to a
+		<a href="https://ckeditor.com">https link like this one.</a>
+	</p>
 	<p>This <strong>is</strong> a <strong>sample</strong> <em>text</em>.</p>
 </div>
 
@@ -40,18 +46,32 @@
 
 					a11ychecker.engine.on( 'process', function( evt ) {
 						var Issue = CKEDITOR.plugins.a11ychecker.Issue,
-							strongs = evt.data.contentElement.find( 'strong' ),
+							contentElement = evt.data.contentElement,
 							issues = evt.data.issues;
+
+						a11ychecker.engine.issueDetails.preferHttpsLinks = {
+							title: 'Prefer HTTPS links',
+							descr: 'It\'s year ' + ( new Date() ).getFullYear() + ' already - our website uses HTTPS. ' +
+								'You should use safe protocol whenever possible.'
+						};
 
 						a11ychecker.engine.issueDetails.avoidStrongs = {
 							title: 'Avoid strongs',
 							descr: 'Our users do not like <strong>strongs</strong>, use <em>emphasize</em> instead 😉'
-						}
+						};
 
-						CKEDITOR.tools.array.forEach( strongs.toArray(), function( strong ) {
+						CKEDITOR.tools.array.forEach( contentElement.find( 'a[href^="http://ckeditor.com"]' ).toArray(), function( link ) {
+							issues.addItem( new Issue( {
+								originalElement: link,
+								testability: Issue.testability.ERROR,
+								id: 'preferHttpsLinks'
+							}, a11ychecker.engine ) );
+						} );
+
+						CKEDITOR.tools.array.forEach( contentElement.find( 'strong' ).toArray(), function( strong ) {
 							issues.addItem( new Issue( {
 								originalElement: strong,
-								testability: Issue.testability.ERROR,
+								testability: Issue.testability.NOTICE,
 								id: 'avoidStrongs'
 							}, a11ychecker.engine ) );
 						} );

--- a/tests/manual/processevent.md
+++ b/tests/manual/processevent.md
@@ -10,7 +10,7 @@ This test adds a totally custom checking rule to Accessibilty Checker.
 
 	## Expected
 
-	AC finds two (custom) "Avoid strongs" errors. Each error is pointing at strong element.
+	AC finds "Prefer HTTPS links" and two "Avoid strongs" (custom) errors.
 
 	## Unexpected
 
@@ -23,6 +23,6 @@ This test adds a totally custom checking rule to Accessibilty Checker.
 
 	## Expected
 
-	AC does not report "Avoid strongs" errors.
+	AC does not report custom errors.
 
 Repeat steps for the inline editor.

--- a/tests/manual/processevent.md
+++ b/tests/manual/processevent.md
@@ -1,0 +1,28 @@
+@bender-include: %TEST_DIR%../_assets/jquery.min.js
+@bender-ui: collapsed
+@bender-ckeditor-plugins: a11ychecker,sourcearea,toolbar,undo,wysiwygarea,clipboard,basicstyles,link,floatingspace,removeformat
+
+# Process event
+
+This test adds a totally custom checking rule to Accessibilty Checker.
+
+1. Enable AC with toolbar button.
+
+	## Expected
+
+	AC finds two (custom) "Avoid strongs" errors. Each error is pointing at strong element.
+
+	## Unexpected
+
+	AC finds no errors.
+
+1. Close AC.
+1. Select entire editor content.
+1. Use remove formatting button.
+1. Enable AC.
+
+	## Expected
+
+	AC does not report "Avoid strongs" errors.
+
+Repeat steps for the inline editor.


### PR DESCRIPTION
This event was required to allow for adding custom Issue types.

Along with that I have added [a short wiki page showing how to do add a new Issue type in Accessibility Checker](https://github.com/cksource/ckeditor-plugin-a11ychecker/wiki/Adding-Custom-Quick-Fixes).

Closes #247.